### PR TITLE
Update rcnn_load_model.m to make it aware of the default CPU/GPU choice.

### DIFF
--- a/rcnn_load_model.m
+++ b/rcnn_load_model.m
@@ -26,7 +26,7 @@ end
 
 rcnn_model.cnn.init_key = ...
     caffe('init', rcnn_model.cnn.definition_file, rcnn_model.cnn.binary_file);
-if exist('use_gpu', 'var') && ~use_gpu
+if (exist('use_gpu', 'var') && ~use_gpu) || ~getfield(rcnn_config,'use_gpu')
   caffe('set_mode_cpu');
 else
   caffe('set_mode_gpu');


### PR DESCRIPTION
When Caffe is built without GPU support, caffe('set_mode_gpu') shouldn't be called. Make rcnn_load_model aware of the default CPU/GPU setting in rcnn_config.m.
