### PR TITLE
solving the error of not finding caffe in matlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ R-CNN bbox reg | 31.4%
   1. if you see `Warning: Please install Caffe in ./external/caffe` most probably instead of folder `caffe` you have `+caffe`, so create another symlink to solve this warning. `ln -sf $CAFFE_ROOT/caffe/matlab/+caffe  $CAFFE_ROOT/caffe/matlab/caffe`.
   0. Run the build script: `>> rcnn_build()` (builds [liblinear](http://www.csie.ntu.edu.tw/~cjlin/liblinear/) and [Selective Search](http://www.science.uva.nl/research/publications/2013/UijlingsIJCV2013/)). Don't worry if you see compiler warnings while building liblinear, this is normal on my system.
   0. Check that Caffe and MATLAB wrapper are set up correctly (this code should run without error): `>> key = caffe('get_init_key');` (expected output is key = -2)
-  1. if you get the error `Undefined function or variable 'caffe'`, most probably you haven't done step 1.
+  1. if you get the error `Undefined function or variable 'caffe'`, most probably you haven't done step vi.
   0. Download the model package, which includes precompute models (see below).
 
 **Common issues:** You may need to set an `LD_LIBRARY_PATH` before you start MATLAB. If you see a message like "Invalid MEX-file '/path/to/rcnn/external/caffe/matlab/caffe/caffe.mexa64': libmkl_rt.so: cannot open shared object file: No such file or directory" then make sure that CUDA and MKL are in your `LD_LIBRARY_PATH`. On my system, I use:

--- a/README.md
+++ b/README.md
@@ -66,8 +66,10 @@ R-CNN bbox reg | 31.4%
   0. R-CNN expects to find Caffe in `external/caffe`, so create a symlink: `ln -sf $CAFFE_ROOT external/caffe`
   0. Start MATLAB (make sure you're still in the `rcnn` directory): `matlab`
   0. You'll be prompted to download the [Selective Search](http://disi.unitn.it/~uijlings/MyHomepage/index.php#page=projects1) code, which we cannot redistribute. Afterwards, you should see the message `R-CNN startup done` followed by the MATLAB prompt `>>`.
+  1. if you see `Warning: Please install Caffe in ./external/caffe` most probably instead of folder `caffe` you have `+caffe`, so create another symlink to solve this warning. `ln -sf $CAFFE_ROOT/caffe/matlab/+caffe  $CAFFE_ROOT/caffe/matlab/caffe`.
   0. Run the build script: `>> rcnn_build()` (builds [liblinear](http://www.csie.ntu.edu.tw/~cjlin/liblinear/) and [Selective Search](http://www.science.uva.nl/research/publications/2013/UijlingsIJCV2013/)). Don't worry if you see compiler warnings while building liblinear, this is normal on my system.
   0. Check that Caffe and MATLAB wrapper are set up correctly (this code should run without error): `>> key = caffe('get_init_key');` (expected output is key = -2)
+  1. if you get the error `Undefined function or variable 'caffe'`, most probably you haven't done step 1.
   0. Download the model package, which includes precompute models (see below).
 
 **Common issues:** You may need to set an `LD_LIBRARY_PATH` before you start MATLAB. If you see a message like "Invalid MEX-file '/path/to/rcnn/external/caffe/matlab/caffe/caffe.mexa64': libmkl_rt.so: cannot open shared object file: No such file or directory" then make sure that CUDA and MKL are in your `LD_LIBRARY_PATH`. On my system, I use:


### PR DESCRIPTION
by making a symlink, the warning and error of matlab concerning not finding caffe folder can be solved.
